### PR TITLE
Rebase onto latest SagerNet/sing-box, restore WireGuard Noise obfuscation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -285,12 +285,7 @@ replace github.com/sagernet/sing-dns => github.com/shtorm-7/sing-dns v0.4.6-exte
 
 replace github.com/ameshkov/dnscrypt/v2 => github.com/shtorm-7/dnscrypt/v2 v2.4.0-extended-1.0.0
 
-// FIXME: hiddify's wireguard-go fork (replace/wireguard-go) predates upstream
-// sagernet/wireguard-go's InputPacketRef/SetSinglePeerMode APIs. Dropped this
-// replace to unblock the v5 merge build; re-verify fork-specific patches
-// (pause support, custom worker size, noise options, windows fix) are either
-// already upstreamed or need porting back before shipping.
-// replace github.com/sagernet/wireguard-go => ./replace/wireguard-go
+replace github.com/sagernet/wireguard-go => ./replace/wireguard-go
 
 replace github.com/sagernet/tailscale => ./replace/tailscale
 

--- a/option/wireguard.go
+++ b/option/wireguard.go
@@ -5,8 +5,15 @@ import (
 
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing/common/json/badoption"
-	hiddify "github.com/sagernet/wireguard-go/hiddify"
 )
+
+type WireGuardNoiseOptions struct { //H
+	FakePackets         []int  `json:"fake_packets,omitempty"`
+	FakePacketsDelays   []int  `json:"fake_packets_delays,omitempty"`
+	FakePacketsSize     []int  `json:"fake_packets_size,omitempty"`
+	FakePacketsHeader   []byte `json:"fake_packets_header,omitempty"`
+	FakePacketsNoModify bool   `json:"fake_packets_no_modify,omitempty"`
+}
 
 type WireGuardEndpointOptions struct {
 	System     bool                             `json:"system,omitempty"`
@@ -20,8 +27,8 @@ type WireGuardEndpointOptions struct {
 	Workers    int                              `json:"workers,omitempty"`
 	DialerOptions
 
-	Noise hiddify.NoiseOptions `json:"noise,omitempty"` //H
-	AWG   *AwgOptions          `json:"awg,omitempty"`   //H
+	Noise WireGuardNoiseOptions `json:"noise,omitempty"` //H
+	AWG   *AwgOptions           `json:"awg,omitempty"`   //H
 }
 
 type WireGuardPeer struct {
@@ -45,8 +52,8 @@ type WARPEndpointOptions struct { //H
 
 	UniqueIdentifier string `json:"unique_identifier,omitempty"`
 	ServerOptions
-	Noise hiddify.NoiseOptions `json:"noise,omitempty"`
-	AWG   *AwgOptions          `json:"awg,omitempty"`
+	Noise WireGuardNoiseOptions `json:"noise,omitempty"`
+	AWG   *AwgOptions           `json:"awg,omitempty"`
 	*C.WARPConfig
 	MTU uint32 `json:"mtu,omitempty"`
 }

--- a/option/wireguard.go
+++ b/option/wireguard.go
@@ -5,15 +5,8 @@ import (
 
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing/common/json/badoption"
+	hiddify "github.com/sagernet/wireguard-go/hiddify"
 )
-
-type WireGuardNoiseOptions struct { //H
-	FakePackets         []int  `json:"fake_packets,omitempty"`
-	FakePacketsDelays   []int  `json:"fake_packets_delays,omitempty"`
-	FakePacketsSize     []int  `json:"fake_packets_size,omitempty"`
-	FakePacketsHeader   []byte `json:"fake_packets_header,omitempty"`
-	FakePacketsNoModify bool   `json:"fake_packets_no_modify,omitempty"`
-}
 
 type WireGuardEndpointOptions struct {
 	System     bool                             `json:"system,omitempty"`
@@ -27,8 +20,8 @@ type WireGuardEndpointOptions struct {
 	Workers    int                              `json:"workers,omitempty"`
 	DialerOptions
 
-	Noise WireGuardNoiseOptions `json:"noise,omitempty"` //H
-	AWG   *AwgOptions           `json:"awg,omitempty"`   //H
+	Noise hiddify.NoiseOptions `json:"noise,omitempty"` //H
+	AWG   *AwgOptions          `json:"awg,omitempty"`   //H
 }
 
 type WireGuardPeer struct {
@@ -52,8 +45,8 @@ type WARPEndpointOptions struct { //H
 
 	UniqueIdentifier string `json:"unique_identifier,omitempty"`
 	ServerOptions
-	Noise WireGuardNoiseOptions `json:"noise,omitempty"`
-	AWG   *AwgOptions           `json:"awg,omitempty"`
+	Noise hiddify.NoiseOptions `json:"noise,omitempty"`
+	AWG   *AwgOptions          `json:"awg,omitempty"`
 	*C.WARPConfig
 	MTU uint32 `json:"mtu,omitempty"`
 }

--- a/option/wireguard.go
+++ b/option/wireguard.go
@@ -5,6 +5,7 @@ import (
 
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing/common/json/badoption"
+	hiddify "github.com/sagernet/wireguard-go/hiddify"
 )
 
 type WireGuardEndpointOptions struct {
@@ -19,7 +20,8 @@ type WireGuardEndpointOptions struct {
 	Workers    int                              `json:"workers,omitempty"`
 	DialerOptions
 
-	AWG *AwgOptions `json:"awg,omitempty"` //H
+	Noise hiddify.NoiseOptions `json:"noise,omitempty"` //H
+	AWG   *AwgOptions          `json:"awg,omitempty"`   //H
 }
 
 type WireGuardPeer struct {
@@ -43,7 +45,8 @@ type WARPEndpointOptions struct { //H
 
 	UniqueIdentifier string `json:"unique_identifier,omitempty"`
 	ServerOptions
-	AWG           *AwgOptions `json:"awg,omitempty"`
+	Noise hiddify.NoiseOptions `json:"noise,omitempty"`
+	AWG   *AwgOptions          `json:"awg,omitempty"`
 	*C.WARPConfig
 	MTU uint32 `json:"mtu,omitempty"`
 }

--- a/protocol/warp/endpoint_warp_wireguard.go
+++ b/protocol/warp/endpoint_warp_wireguard.go
@@ -29,6 +29,7 @@ func createWARPWireGuardEndpoint(
 		ListenPort:                 options.ListenPort,
 		UDPTimeout:                 options.UDPTimeout,
 		Workers:       options.Workers,
+		Noise:         options.Noise,
 		AWG:           options.AWG,
 		DialerOptions: options.DialerOptions,
 		Address: badoption.Listable[netip.Prefix]{

--- a/protocol/wireguard/endpoint.go
+++ b/protocol/wireguard/endpoint.go
@@ -109,6 +109,7 @@ func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextL
 			}
 		}),
 		Workers: options.Workers,
+		Noise:   options.Noise,
 	})
 	if err != nil {
 		return nil, err

--- a/transport/wireguard/endpoint.go
+++ b/transport/wireguard/endpoint.go
@@ -188,7 +188,11 @@ func (e *Endpoint) Start(resolve bool) error {
 		},
 	}
 	wgDevice := device.NewDevice(e.options.Context, e.returnDevice, bind, logger, e.options.Workers)
-	wgDevice.HNoise = e.options.Noise
+	wgDevice.FakePackets = e.options.Noise.FakePackets           //H
+	wgDevice.FakePacketsDelays = e.options.Noise.FakePacketsDelays //H
+	wgDevice.FakePacketsSize = e.options.Noise.FakePacketsSize     //H
+	wgDevice.FakePacketsHeader = e.options.Noise.FakePacketsHeader //H
+	wgDevice.FakePacketsNoModify = e.options.Noise.FakePacketsNoModify //H
 	e.tunDevice.SetDevice(wgDevice)
 	var ipcConf strings.Builder
 	ipcConf.WriteString(e.ipcConf)

--- a/transport/wireguard/endpoint.go
+++ b/transport/wireguard/endpoint.go
@@ -188,11 +188,7 @@ func (e *Endpoint) Start(resolve bool) error {
 		},
 	}
 	wgDevice := device.NewDevice(e.options.Context, e.returnDevice, bind, logger, e.options.Workers)
-	wgDevice.FakePackets = e.options.Noise.FakePackets           //H
-	wgDevice.FakePacketsDelays = e.options.Noise.FakePacketsDelays //H
-	wgDevice.FakePacketsSize = e.options.Noise.FakePacketsSize     //H
-	wgDevice.FakePacketsHeader = e.options.Noise.FakePacketsHeader //H
-	wgDevice.FakePacketsNoModify = e.options.Noise.FakePacketsNoModify //H
+	wgDevice.HNoise = e.options.Noise //H
 	e.tunDevice.SetDevice(wgDevice)
 	var ipcConf strings.Builder
 	ipcConf.WriteString(e.ipcConf)

--- a/transport/wireguard/endpoint.go
+++ b/transport/wireguard/endpoint.go
@@ -188,6 +188,7 @@ func (e *Endpoint) Start(resolve bool) error {
 		},
 	}
 	wgDevice := device.NewDevice(e.options.Context, e.returnDevice, bind, logger, e.options.Workers)
+	wgDevice.HNoise = e.options.Noise
 	e.tunDevice.SetDevice(wgDevice)
 	var ipcConf strings.Builder
 	ipcConf.WriteString(e.ipcConf)

--- a/transport/wireguard/endpoint_options.go
+++ b/transport/wireguard/endpoint_options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sagernet/sing/common/logger"
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
+	hiddify "github.com/sagernet/wireguard-go/hiddify"
 )
 
 type EndpointOptions struct {
@@ -28,6 +29,7 @@ type EndpointOptions struct {
 	ResolvePeer  func(domain string) (netip.Addr, error)
 	Peers        []PeerOptions
 	Workers      int
+	Noise        hiddify.NoiseOptions //H
 }
 
 type PeerOptions struct {

--- a/transport/wireguard/endpoint_options.go
+++ b/transport/wireguard/endpoint_options.go
@@ -5,11 +5,11 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common/logger"
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
+	hiddify "github.com/sagernet/wireguard-go/hiddify"
 )
 
 type EndpointOptions struct {
@@ -29,7 +29,7 @@ type EndpointOptions struct {
 	ResolvePeer  func(domain string) (netip.Addr, error)
 	Peers        []PeerOptions
 	Workers      int
-	Noise        option.WireGuardNoiseOptions //H
+	Noise        hiddify.NoiseOptions //H
 }
 
 type PeerOptions struct {

--- a/transport/wireguard/endpoint_options.go
+++ b/transport/wireguard/endpoint_options.go
@@ -5,11 +5,11 @@ import (
 	"net/netip"
 	"time"
 
+	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common/logger"
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
-	hiddify "github.com/sagernet/wireguard-go/hiddify"
 )
 
 type EndpointOptions struct {
@@ -29,7 +29,7 @@ type EndpointOptions struct {
 	ResolvePeer  func(domain string) (netip.Addr, error)
 	Peers        []PeerOptions
 	Workers      int
-	Noise        hiddify.NoiseOptions //H
+	Noise        option.WireGuardNoiseOptions //H
 }
 
 type PeerOptions struct {


### PR DESCRIPTION
## Summary
Continuation of #30 (closed) — rebases hiddify's fork onto the latest `SagerNet/sing-box` (`testing` branch), reorganized into 42 logical commits by feature instead of a 386-commit-deep replayed history, plus the WireGuard Noise fake-packet obfuscation fix and a full `with_tailscale`/`with_cloudflared`/`with_masque` build fix (see below).

## Approach
- Merged `testing-merge-base` with latest `SagerNet/sing-box` in a reference tree, favoring hiddify's side on conflicts.
- Started a clean checkout of upstream `SagerNet/sing-box` (testing branch) as the new base.
- Ported every hiddify feature cluster (protocols, transports, DNS, route rules, daemon/libbox integration, build infra) onto that clean base, reconciling each against upstream's current APIs rather than blindly copying hiddify's old code.
- Grouped the result into commits by feature area — see `git log --oneline` on this branch for the full list.

## WireGuard Noise obfuscation — fixed
`replace/wireguard-go` originally predated upstream's `InputPacketRef`/`SetSinglePeerMode` APIs and had to be disabled. Fixed via [hiddify/wireguard-go#3](https://github.com/hiddify/wireguard-go/pull/3) — a single-commit, 7-file patch that adds just the Noise/`SendWithoutModify` feature directly on top of `sagernet/wireguard-go:dev`'s current HEAD (the exact commit `go.mod` pins), rather than merging the fork's full history. `option.WireGuardEndpointOptions`/`WARPEndpointOptions.Noise` uses `hiddify.NoiseOptions` (struct-based, `Count`/`Size`/`Delay` ranges), and the `replace` directive is re-enabled.

## `with_tailscale` / `with_cloudflared` / `with_masque` build fixes
The plain `go build ./...` (no tags) was clean, but these three build-tag-gated packages weren't — meaning they'd been silently broken since the rebase. All now build and vet clean under the full `release/DEFAULT_BUILD_TAGS` set:

- **cloudflare**: `sing-cloudflared`'s `ICMPHandler` interface changed from a session-based `RouteICMPConnection` to `RouteICMPFlow(source, destination) (tun.Port, error)`. Rewired to extract a `tun.Port` from the router's `PreMatchResult`.
- **tailscale**: the biggest one. `adapter.DirectRouteOutbound` (old session-based ICMP routing) is gone, replaced by `adapter.FlowOutbound` (`tun.Port` + `PreMatchFlow`). Endpoint's ICMP flow routing now backs onto `sing-tun`'s `ping.Port` instead of removed helpers. Also: fixed `PreferredAddress`/`PreferredDomain` signatures (gained a `*adapter.InboundContext` param), added the now-required `Logout` method, and stubbed three removed hooks with no current replacement — `netns.SetControlFunc` (only the Android protect-func path has one), `tsnet.Server.PeerDNSQueryHandler`, and `LocalBackend.SetExternalSSHHostKeys` — each documented inline as a follow-up.
- **masque**: same `tun.NewICMPForwarder` signature drift as cloudflare/tailscale.
- **wireguard (legacy outbound)**: turned out to have never been registered at all — `protocol/wireguard.RegisterOutbound` existed but had no call site, so configs silently hit upstream's "WireGuard outbound is deprecated, use endpoint instead" stub. Registered under a new `wireguard_legacy` type (not `wireguard`) so upstream's deprecation stays intact for the old name.

Note: full-tag builds also require dropping the `badlinkname` tag on Go 1.25.6 specifically — that's a pre-existing upstream `crypto/tls` linkname fragility unrelated to this PR (confirmed the affected file, `common/badtls`, was untouched by any commit here).

## Manual testing
Built with the full default tag set and ran `sing-box check` against configs for every ported feature cluster: WireGuard+Noise, AmneziaWG, WARP, VLESS+XHTTP, VLESS+Vision(xray-vision), mieru, snell, psiphon, balancer, hinvalid, dnstt, gooserelay, tunnel_client, SSH in/outbound, legacy WireGuard outbound, MASQUE, monitoring, proxyproto, cloudflared inbound, smart_dns_pool. All construct and start/stop cleanly. Did not do a live network handshake test (would need real servers/sudo-level WireGuard interfaces) — config-level validation only.

## Known follow-ups (not in this PR)
- **NetNs (network namespace) support** for the tun inbound was dropped — upstream's tun/adapter rework doesn't have an equivalent yet; needs re-porting.
- A few option struct fields (`TLSFragmentOptions`, `TLSTricksOptions`) are carried over as config-schema placeholders with no wired-up implementation, matching their state in the pre-rebase tree.
- Tailscale: non-Android auto-redirect-mark socket control, peer DNS query interception, and custom SSH server host-key status reporting have no current upstream hook (see inline comments in `protocol/tailscale/endpoint.go`/`status.go`/`tailssh/server.go`).

## Test plan
- [x] `go build ./...` succeeds (no tags)
- [x] `go build` with full `release/DEFAULT_BUILD_TAGS` (minus `badlinkname`) succeeds
- [x] `go vet ./...` clean under the same tag set (aside from pre-existing upstream-only issues in files this PR didn't touch)
- [x] `sing-box check` against configs for every ported protocol — all construct/start/stop cleanly
- [ ] Live network handshake test (real WireGuard/VLESS/etc. servers) — not done, recommend before merge
